### PR TITLE
Lock smithy-cli buildscript dependencies explicitly

### DIFF
--- a/model/build.gradle
+++ b/model/build.gradle
@@ -17,6 +17,9 @@ buildscript {
     repositories {
         mavenCentral()
     }
+    dependencies {
+        classpath "software.amazon.smithy:smithy-cli:1.19.0"
+    }
 }
 
 plugins {

--- a/server/codegen/build.gradle
+++ b/server/codegen/build.gradle
@@ -28,6 +28,7 @@ buildscript {
         classpath "software.amazon.smithy:smithy-openapi:1.19.0"
         classpath "software.amazon.smithy:smithy-aws-traits:1.19.0"
         classpath "software.amazon.smithy:smithy-aws-apigateway-openapi:1.19.0"
+        classpath "software.amazon.smithy:smithy-cli:1.19.0"
     }
 }
 

--- a/typescript-client/codegen/build.gradle
+++ b/typescript-client/codegen/build.gradle
@@ -25,6 +25,7 @@ buildscript {
         classpath 'software.amazon.smithy.typescript:smithy-typescript-codegen:0.11.0'
         classpath 'software.amazon.smithy.typescript:smithy-aws-typescript-codegen:0.11.0'
         classpath "software.amazon.smithy:smithy-model:1.19.0"
+        classpath "software.amazon.smithy:smithy-cli:1.19.0"
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/smithy-server-generator-typescript-sample/issues/3

*Description of changes:*
When the Smithy plugin loads a smithy-cli dependency, it can find a recent
release that is not compatible with the version used by the build file. By
explicitly declaring a smithy-cli buildscript dependency, we prevent this from
happening.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
